### PR TITLE
feat: update arrowParens rule to always use parens

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  arrowParens: 'avoid',
+  arrowParens: 'always',
   bracketSpacing: true,
   jsxBracketSameLine: false,
   jsxSingleQuote: true,


### PR DESCRIPTION
Resolves #71

BREAKING CHANGE: This is a change in the supplied config and will result
in arrow functions now always wrapping the arguments in parentheses.